### PR TITLE
🐛 FIX: RTD fail - install extension locally

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,7 @@ sphinx:
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - rtd

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ extensions = ["sphinx_exercise"]
 
 ## Documentation
 
-See the [Sphinx Exercise documentation](https://sphinx-exercise.readthedocs.io/en/latest/) for more information.
+See the [Sphinx Exercise documentation](https://ebp-sphinx-exercise.readthedocs.io/en/latest/) for more information.
 
 
 ## Contributing
@@ -37,8 +37,8 @@ See the [Sphinx Exercise documentation](https://sphinx-exercise.readthedocs.io/e
 We welcome all contributions! See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contributing.html) for general details, and below for guidance specific to sphinx-exercise.
 
 
-[rtd-badge]: https://readthedocs.org/projects/sphinx-exercise/badge/?version=latest
-[rtd-link]: https://sphinx-exercise.readthedocs.io/en/latest/?badge=latest
+[rtd-badge]: https://readthedocs.org/projects/ebp-sphinx-exercise/badge/?version=latest
+[rtd-link]: https://ebp-sphinx-exercise.readthedocs.io/en/latest/?badge=latest
 [github-ci]: https://github.com/executablebooks/sphinx-exercise/workflows/continuous-integration/badge.svg?branch=master
 [github-link]: https://github.com/executablebooks/sphinx-exercise
 [codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-exercise/branch/master/graph/badge.svg

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -8,7 +8,10 @@ syntax
 testing
 ```
 
-[![Documentation Status](https://readthedocs.org/projects/sphinx-exercise/badge/?version=latest)](https://sphinx-exercise.readthedocs.io/en/latest/?badge=latest)
+
+[![Documentation Status][rtd-badge]][rtd-link]
+[![Github-CI][github-ci]][github-link]
+[![Coverage Status][codecov-badge]][codecov-link]
 
 **An exercise extension for Sphinx**.
 
@@ -64,3 +67,12 @@ extensions = ["sphinx_exercise"]
 ```
 
 you may then build using `make html` and the extension will be used by your `Sphinx` project.
+
+
+
+[rtd-badge]: https://readthedocs.org/projects/ebp-sphinx-exercise/badge/?version=latest
+[rtd-link]: https://ebp-sphinx-exercise.readthedocs.io/en/latest/?badge=latest
+[github-ci]: https://github.com/executablebooks/sphinx-exercise/workflows/continuous-integration/badge.svg?branch=master
+[github-link]: https://github.com/executablebooks/sphinx-exercise
+[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-exercise/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/executablebooks/sphinx-exercise

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ extras = testing
 deps =
 	sphinx2: sphinx>=2,<3
 	sphinx3: sphinx>=3,<4
-commands = pytest {posargs}
+commands = pytest --verbose {posargs}
 
 [testenv:docs-{update,clean}]
 extras = rtd


### PR DESCRIPTION
This PR allows RTD to install requirements from `extras["rtd"]`.