### PR TITLE
🐛 FIX: Manifest recursive-include path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,5 @@ include LICENSE
 include MANIFEST.in
 include README.md
 
-recursive-include sphinx *.js
-recursive-include sphinx *.css
+recursive-include sphinx_exercise *.js
+recursive-include sphinx_exercise *.css


### PR DESCRIPTION
This PR fixes the recursive-include path to point to sphinx_exercise.