### PR TITLE
🐛 FIX: Check during doctree-resolve if env has attribute

### DIFF
--- a/sphinx_exercise/__init__.py
+++ b/sphinx_exercise/__init__.py
@@ -313,6 +313,9 @@ class DoctreeResolve:
         # Traverse ref and numref nodes
         for node in doctree.traverse():
 
+            if not hasattr(self.env, "exercise_list"):
+                continue
+
             # If node type is ref
             if isinstance(node, nodes.reference):
                 labelid = self._get_refuri(node)


### PR DESCRIPTION
This PR fixes `doctree-resolve` in the event that the extension is imported but not used.