### PR TITLE
👌 IMPROVE: Link exercise portion of solution title in directive

### DIFF
--- a/sphinx_exercise/__init__.py
+++ b/sphinx_exercise/__init__.py
@@ -192,10 +192,12 @@ class DoctreeResolve:
         )
         refnode["refuri"] += "#" + target_labelid
         inline = nodes.inline()
-        for item in node[0]:
+        title_node = node[0][0]
+        for item in node[0][1:]:
             inline.append(item)
         refnode += inline
         newnode += refnode
+        newnode.insert(0, title_node)
         node[0].replace_self(newnode)
 
         # update node
@@ -241,7 +243,7 @@ class DoctreeResolve:
             target_node = target_attr.get("node", Node)
 
             if is_enumerable_node(target_node) and node.astext() == default_title:
-                node.replace(node[0], source_node[0][0][0])
+                node[0].extend(source_node[0][1][0])
                 return
 
             if is_unenumerable_node(target_node) and node.astext() == default_title:

--- a/sphinx_exercise/_static/exercise.css
+++ b/sphinx_exercise/_static/exercise.css
@@ -43,10 +43,6 @@ div.solution p.admonition-title {
   text-decoration: none;
 }
 
-div.solution p.admonition-title a {
-  color: #333 !important;
-}
-
 /* Remove content box */
 div.solution p.admonition-title::before {
   content: none;

--- a/tests/test_solution/_linked_enum.html
+++ b/tests/test_solution/_linked_enum.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-number">
-<p class="admonition-title"><a class="reference external" href="#ex-number"><span>Solution to Exercise 6</span></a></p>
+<p class="admonition-title">Solution to <a class="reference external" href="#ex-number"><span>Exercise 6</span></a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 <div class="math notranslate nohighlight">

--- a/tests/test_solution/_linked_enum_class.html
+++ b/tests/test_solution/_linked_enum_class.html
@@ -1,5 +1,5 @@
 <div class="solution test-solution admonition" id="solution-label">
-<p class="admonition-title"><a class="reference external" href="_linked_enum.html#ex-number"><span>Solution to Exercise 6</span></a></p>
+<p class="admonition-title">Solution to <a class="reference external" href="_linked_enum.html#ex-number"><span>Exercise 6</span></a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_ref_enum.html
+++ b/tests/test_solution/_linked_ref_enum.html
@@ -1,2 +1,2 @@
-<p>referencing: <a class="reference internal" href="_linked_enum.html#sol-number"><span>Solution to Exercise 6</span></a>.</p>
+<p>referencing: <a class="reference internal" href="_linked_enum.html#sol-number"><span class="std std-ref">Solution to Exercise 6</span></a>.</p>
 <p>referencing: <a class="reference internal" href="_linked_enum.html#sol-number"><span class="std std-ref">simple solution with number</span></a>.</p>

--- a/tests/test_solution/_linked_unenum_mathtitle.html
+++ b/tests/test_solution/_linked_unenum_mathtitle.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-title-math">
-<p class="admonition-title"><a class="reference external" href="#ex-nonumber-title-math"><span>Solution to This is a title <span class="math notranslate nohighlight">\(\mathbb{R}\)</span></span></a></p>
+<p class="admonition-title">Solution to <a class="reference external" href="#ex-nonumber-title-math"><span>This is a title <span class="math notranslate nohighlight">\(\mathbb{R}\)</span></span></a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_mathtitle2.html
+++ b/tests/test_solution/_linked_unenum_mathtitle2.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-title-math2">
-<p class="admonition-title"><a class="reference external" href="#ex-nonumber-title-math2"><span>Solution to This is a title <span class="math notranslate nohighlight">\(P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\)</span></span></a></p>
+<p class="admonition-title">Solution to <a class="reference external" href="#ex-nonumber-title-math2"><span>This is a title <span class="math notranslate nohighlight">\(P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\)</span></span></a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_notitle.html
+++ b/tests/test_solution/_linked_unenum_notitle.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-notitle">
-<p class="admonition-title"><a class="reference external" href="#ex-nonumber-notitle"><span>Solution to Exercise</span></a></p>
+<p class="admonition-title">Solution to <a class="reference external" href="#ex-nonumber-notitle"><span>Exercise</span></a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_title.html
+++ b/tests/test_solution/_linked_unenum_title.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-title">
-<p class="admonition-title"><a class="reference external" href="#ex-nonumber-title"><span>Solution to This is a title</span></a></p>
+<p class="admonition-title">Solution to <a class="reference external" href="#ex-nonumber-title"><span>This is a title</span></a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>


### PR DESCRIPTION
This PR marks portion of `solution`'s title as a reference to the exercise directive and reverts the color of that link to its default color. It implements option 1 in #12.