### PR TITLE
FIX: Update style for solution titles to agree with #12

### DIFF
--- a/sphinx_exercise/post_transforms.py
+++ b/sphinx_exercise/post_transforms.py
@@ -139,9 +139,8 @@ def resolve_solution_title(app, node, exercise_node):
     title = node.children[0]
     exercise_title = exercise_node.children[0]
     if isinstance(title, solution_title):
-        updated_title_text = (
-            node.get("title") + " " + exercise_title.children[0].astext()
-        )
+        entry_title_text = node.get("title")
+        updated_title_text = " " + exercise_title.children[0].astext()
         if isinstance(exercise_node, exercise_enumerable_node):
             node_number = get_node_number(app, exercise_node, "exercise")
             updated_title_text += f" {node_number}"
@@ -149,7 +148,7 @@ def resolve_solution_title(app, node, exercise_node):
         updated_title = docutil_nodes.title()
         wrap_reference = build_reference_node(app, exercise_node)
         wrap_reference += docutil_nodes.Text(updated_title_text)
-        node["title"] = updated_title_text
+        node["title"] = entry_title_text + updated_title_text
         # Parse Custom Titles from Exercise
         if len(exercise_title.children) > 1:
             subtitle = exercise_title.children[1]
@@ -163,6 +162,7 @@ def resolve_solution_title(app, node, exercise_node):
                         domain.data["has_equations"][app.env.docname] = True
                     wrap_reference += child
                 wrap_reference += docutil_nodes.Text(")")
+        updated_title += docutil_nodes.Text(entry_title_text)
         updated_title += wrap_reference
         updated_title.parent = title.parent
         node.children[0] = updated_title

--- a/tests/test_solution/_linked_enum.html
+++ b/tests/test_solution/_linked_enum.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-number">
-<p class="admonition-title"><a class="reference internal" href="#ex-number">Solution to Exercise 6 (This is a title)</a></p>
+<p class="admonition-title">Solution to<a class="reference internal" href="#ex-number"> Exercise 6 (This is a title)</a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 <div class="math notranslate nohighlight">

--- a/tests/test_solution/_linked_enum_class.html
+++ b/tests/test_solution/_linked_enum_class.html
@@ -1,5 +1,5 @@
 <div class="solution test-solution admonition" id="solution-label">
-<p class="admonition-title"><a class="reference internal" href="_linked_enum.html#ex-number">Solution to Exercise 6 (This is a title)</a></p>
+<p class="admonition-title">Solution to<a class="reference internal" href="_linked_enum.html#ex-number"> Exercise 6 (This is a title)</a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_mathtitle.html
+++ b/tests/test_solution/_linked_unenum_mathtitle.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-title-math">
-<p class="admonition-title"><a class="reference internal" href="#ex-nonumber-title-math">Solution to Exercise (This is a title <span class="math notranslate nohighlight">\(\mathbb{R}\)</span>)</a></p>
+<p class="admonition-title">Solution to<a class="reference internal" href="#ex-nonumber-title-math"> Exercise (This is a title <span class="math notranslate nohighlight">\(\mathbb{R}\)</span>)</a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_mathtitle2.html
+++ b/tests/test_solution/_linked_unenum_mathtitle2.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-title-math2">
-<p class="admonition-title"><a class="reference internal" href="#ex-nonumber-title-math2">Solution to Exercise (This is a title <span class="math notranslate nohighlight">\(P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\)</span>)</a></p>
+<p class="admonition-title">Solution to<a class="reference internal" href="#ex-nonumber-title-math2"> Exercise (This is a title <span class="math notranslate nohighlight">\(P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\)</span>)</a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_notitle.html
+++ b/tests/test_solution/_linked_unenum_notitle.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-notitle">
-<p class="admonition-title"><a class="reference internal" href="#ex-nonumber-notitle">Solution to Exercise</a></p>
+<p class="admonition-title">Solution to<a class="reference internal" href="#ex-nonumber-notitle"> Exercise</a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>

--- a/tests/test_solution/_linked_unenum_title.html
+++ b/tests/test_solution/_linked_unenum_title.html
@@ -1,5 +1,5 @@
 <div class="solution admonition" id="sol-nonumber-title">
-<p class="admonition-title"><a class="reference internal" href="#ex-nonumber-title">Solution to Exercise (This is a title)</a></p>
+<p class="admonition-title">Solution to<a class="reference internal" href="#ex-nonumber-title"> Exercise (This is a title)</a></p>
 <div class="section" id="solution-content">
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
 </div>


### PR DESCRIPTION
This re-applies the style for `solution` node titles as discussed in #12 