### PR TITLE
MAINT: tidy up and migrate to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: continuous-integration
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       - 'v*'
   pull_request:

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from setuptools import setup, find_packages
 VERSION = "v0.3.1"
 
 LONG_DESCRIPTION = """
-This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
+This package contains a [Sphinx](http://www.sphinx-doc.org/) extension
 for producing exercise and solution directives.
 
-This project is maintained and supported by [najuzilu](https://github.com/najuzilu).
+This project is maintained and supported by the Executable Books Project.
 """
 
 SHORT_DESCRIPTION = "A Sphinx extension for producing exercises and solutions."


### PR DESCRIPTION
Minor tidy and migrate to using `main`

- [x] change default branch name from `main` to `master`
- [x] merge after #45 